### PR TITLE
Use bit twiddling to manage NaN cases

### DIFF
--- a/batchPhysics.js
+++ b/batchPhysics.js
@@ -173,14 +173,9 @@ BruteFrog.prototype.fasterSqrts = function (xSq, x) {
     }
 
     for (i = 0; i < x32IntLo.length; i += 2) {
-        if ((x32IntLo[i] & 0x7f800000) === 0x7f800000) {
-            x32IntLo[i] = ~0;
-            x32IntHi[i] = ~0;
-        } else if (x32FloatLo[i] < 0) {
-            x32IntLo[i] = ~0;
-            x32IntHi[i] = ~0;
-        } else {
-
+        x32IntLo[i] |= x32IntLo[i] >> 31;
+        // Input now either NaN, 0 <= x32IntLo[i], or +Infinity
+        if ((x32IntLo[i] & 0x7f800000) !== 0x7f800000) {
             // Guess such that bias+exp/2 is in higher 16 bits
             // (exp%2, Mantissa) in lower 16 bits
             x32IntLo[i] += 0x3f800000;

--- a/tests/MathExtend.js
+++ b/tests/MathExtend.js
@@ -1,13 +1,16 @@
 Math.relativeTol = 1E-5;
 Math.absoluteTol = 1E-8;
 
-Math.isClose = function(a, b){
-  //Based on Numpy implementation:
-  //http://docs.scipy.org/doc/numpy-dev/reference/generated/numpy.isclose.html
-  if(a != a){
-    return (b != b);//Return true is both are NaN
-  }else{
-    return (Math.abs(a-b) <= Math.absoluteTol + Math.relativeTol * Math.abs(b));
-  }
+Math.isClose = function (a, b) {
+    "use strict";
+    //Based on Numpy implementation:
+    //http://docs.scipy.org/doc/numpy-dev/reference/generated/numpy.isclose.html
+    if (Number.isNaN(a) && Number.isNaN(b)) {
+        return true;
+    } else if (a === b) {
+        return true;
+    } else {
+        return (Math.abs(a - b) <= Math.absoluteTol + Math.relativeTol * Math.abs(b));
+    }
 };
 

--- a/tests/SquareRootTests.js
+++ b/tests/SquareRootTests.js
@@ -1,6 +1,7 @@
 SquareRootTests = function(numSamples){
   var i;
   var numFailed = 0;
+  var numSpecialCases;
   if(numSamples < 2){
     numSamples = 3;
   }
@@ -11,13 +12,16 @@ SquareRootTests = function(numSamples){
   f.push(-1);
   f.push(-2);
   f.push(-4);
-  f.push(-NaN);
-  f.push(NaN);
 
-  f.push(-Infinity);
-  f.push(Infinity);
+  f.push(-Number.NaN);
+  f.push( Number.NaN);
 
-  for(i=0; i < numSamples; i++){
+  f.push(Number.POSITIVE_INFINITY);
+  f.push(Number.NEGATIVE_INFINITY);
+
+  numSpecialCases = f.length;
+  numSamples += numSpecialCases;
+  for(i=numSpecialCases; i < numSamples; i++){
     f.push(Math.random());
     f[i] /= (1-f[i]);
   }
@@ -35,10 +39,10 @@ SquareRootTests = function(numSamples){
   BruteFrog.prototype.fasterSqrts(f, fMySquareRoot);
   console.log("Done.\n");
 
-  for(i = 0; i < f.length; i++){
+  for(i = 0; i < f.length; i += 1){
     if (!Math.isClose(fSquareRootExact[i], fMySquareRoot[i])){
-      numFailed ++;
-      console.log("Element " + i + ": " +f[i].toPrecision(4) + ", " + fSquareRootExact[i].toPrecision(4) + ", " + fMySquareRoot[i].toPrecision(4));
+        console.log("Element " + i + ": " +f[i].toPrecision(4) + ", " + fSquareRootExact[i].toPrecision(4) + ", " + fMySquareRoot[i].toPrecision(4));
+        numFailed++;
     }
   }
 


### PR DESCRIPTION
Replaced explicit checks for either NaN or negative input with a single
bitwise operation to set output to NaN.

Changed test cases from global Infinity, NaN to their Number
implementation.