### PR TITLE
T loop unroll

### DIFF
--- a/tests/SquareRootTests.js
+++ b/tests/SquareRootTests.js
@@ -40,7 +40,10 @@ var squareRootTests = function SquareRootTests(numRandomSamples) {
 
     stopWatch = new Date();
     var fSquareRootExact = f.map(Math.sqrt);
-    timings.push({testName: "Float64Array.map( Math.sqrt )", testTime: new Date() - stopWatch});
+    timings.push({testName: "Float64Array.map(Math.sqrt)", testTime: new Date() - stopWatch});
+
+
+
 
     stopWatch = new Date();
     for (i = 0; i < f.length; i += 1) {
@@ -49,8 +52,20 @@ var squareRootTests = function SquareRootTests(numRandomSamples) {
     timings.push({testName: "for loop on Math.sqrt(Float64Array[i])", testTime: new Date() - stopWatch});
 
     stopWatch = new Date();
+    var iMax = f.length;
+    for (i = 0; i < iMax; i += 1) {
+        fSquareRootExact[i] = Math.sqrt(f[i]);
+    }
+    timings.push({testName: "for loop with cached length on Math.sqrt(Float64Array[i])", testTime: new Date() - stopWatch});
+
+
+
+    stopWatch = new Date();
     BruteFrog.prototype.fasterSqrts(f, fMySquareRoot);
     timings.push({testName: "BruteFrog.fasterSqrts()", testTime: new Date() - stopWatch});
+
+
+
 
     stopWatch = new Date();
     for (i = 0; i < f.length; i += 8) {

--- a/tests/SquareRootTests.js
+++ b/tests/SquareRootTests.js
@@ -52,6 +52,18 @@ var squareRootTests = function SquareRootTests(numRandomSamples) {
     BruteFrog.prototype.fasterSqrts(f, fMySquareRoot);
     timings.push({testName: "BruteFrog.fasterSqrts()", testTime: new Date() - stopWatch});
 
+    stopWatch = new Date();
+    for (i = 0; i < f.length; i += 8) {
+        fSquareRootExact[i + 0] = Math.sqrt(f[i + 0]);
+        fSquareRootExact[i + 1] = Math.sqrt(f[i + 1]);
+        fSquareRootExact[i + 2] = Math.sqrt(f[i + 2]);
+        fSquareRootExact[i + 3] = Math.sqrt(f[i + 3]);
+        fSquareRootExact[i + 4] = Math.sqrt(f[i + 4]);
+        fSquareRootExact[i + 5] = Math.sqrt(f[i + 5]);
+        fSquareRootExact[i + 6] = Math.sqrt(f[i + 6]);
+        fSquareRootExact[i + 7] = Math.sqrt(f[i + 7]);
+    }
+    timings.push({testName: "Unrolled for loop on Math.sqrt(Float64Array[i])", testTime: new Date() - stopWatch});
 
     var numRandomDisplay = 20;
     for (i = numSpecialCases; i < f.length; i += 1) {


### PR DESCRIPTION
Add loop unrolling as a candidate.  Results:

Test name: Float64Array.map(Math.sqrt)
Time (ms): 334

Test name: for loop on Math.sqrt(Float64Array[i])
Time (ms): 62

Test name: for loop with cached length on Math.sqrt(Float64Array[i])
Time (ms): 20

Test name: BruteFrog.fasterSqrts()
Time (ms): 40

Test name: Unrolled for loop on Math.sqrt(Float64Array[i])
Time (ms): 7

Conclusion: Unrolled vanilla for-loop is by *very* far the fastest candidate.


