### PR TITLE
Simplify vector allocation

### DIFF
--- a/tests/PhysicsTests.js
+++ b/tests/PhysicsTests.js
@@ -17,7 +17,7 @@ var physicsTests = function () {
     bFrog = new BruteFrog(1);
     passed = passed && bFrog;
 
-    bFrog = new BruteFrog(125);
+    bFrog = new BruteFrog(128);
     for (i = 0; i < bFrog.allRows.length; i += 1) {
         bFrog.allRows[i] = Math.randBroad();
     }


### PR DESCRIPTION
Uses `typedArray.subarray(elements)` rather than
`new typed array(buffer, bytes)`.

Changes the working buffer table names to reflect physics naming
conventions.
